### PR TITLE
Improve verbose build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore compiled Haskell files
+*.o
+*.hi
+*.dyn_o
+*.dyn_hi
+# Build logs
+build.log
+
+
+# Editor swap files
+*~
+.*.sw?

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,0 +1,26 @@
+# Default tmux configuration for Osker development
+
+# Enable mouse interaction
+set -g mouse on
+
+# Keep more history in the scrollback buffer
+set -g history-limit 10000
+
+# Start numbering of windows and panes at 1
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Simple status bar colors
+set -g status-bg colour234
+set -g status-fg colour136
+
+# Plugins managed with TPM
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+run '~/.tmux/plugins/tpm/tpm'
+
+# Use Ctrl-a as the prefix key like GNU Screen
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix

--- a/Posix/Makefile
+++ b/Posix/Makefile
@@ -9,6 +9,8 @@ include ../dirs.mk
 HC        = ghc
 INCS      = 
 HCFLAGS   = $(DEFS) $(OPTS) -cpp -syslib concurrent -syslib data
+# Enable warnings for easier debugging
+HCFLAGS  += -Wall
 HS_IGNORE = Test.hs
 HS_SRCS   = ${filter-out ${HS_IGNORE}, $(wildcard *.hs)}
 OBJS      = $(addsuffix .o,$(basename $(HS_SRCS)))

--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@ Osker
 =====
 
 Sharing work on resumption monad
+
+Setup
+-----
+Run `./setup.sh` to prepare the development environment.  The script
+shows which tmux related packages are available, installs the tools
+required for building the Haskell sources along with QEMU for
+virtualization experiments, and writes a tmux configuration using the
+plugin manager.  It installs debugging utilities such as `shellcheck`
+and `hlint` and performs a verbose build of the `Posix` directory.
+All compiler output is recorded in `build.log` for later review.
+
+Usage
+-----
+After running the setup you can build each part of Osker using the
+provided Makefiles. For example:
+
+```
+cd Posix
+make
+```
+
+Use tmux to keep multiple build shells or editors open during
+development.
+
+Building
+--------
+The Makefiles expect a `dirs.mk` file that is not included in this
+repository. The setup script still runs a small build of the `Posix`
+directory so that missing dependencies are surfaced in `build.log`. Once
+you provide `dirs.mk` you can build each component normally with
+`make`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Setup script for the Osker development environment.
+# Installs Haskell tooling, tmux helpers and QEMU.  A small build is
+# attempted so that any compiler issues surface immediately.
+
+set -euo pipefail
+# Print each command before executing so that failures are easy to spot
+set -x
+
+# Display available tmux related packages so they can be installed if desired.
+list_tmux_packages() {
+    apt-cache search tmux | awk '{print "    " $0}'
+}
+
+# Install packages required for building Osker and running QEMU
+install_packages() {
+    sudo apt-get update
+    sudo apt-get install -y \
+        build-essential git make \
+        ghc cabal-install \
+        tmux tmux-plugin-manager python3-libtmux python3-tmuxp \
+        qemu-system-x86 qemu-system-arm qemu-utils \
+        shellcheck hlint gdb strace
+}
+
+
+# Try building a simple component to verify the Haskell toolchain.
+# Run a small build and log the output for review.  Failures are allowed so
+# the script can continue even if build prerequisites are missing.
+build_osker() {
+    (
+        cd Posix && \
+        make --debug=v quick 2>&1 | tee ../build.log
+    ) || true
+}
+
+# Install a default tmux configuration tailored for development.
+install_tmux_conf() {
+    cat <<'TMUXCONF' > "$HOME/.tmux.conf"
+# Enable mouse support and longer history.
+set -g mouse on
+set -g history-limit 10000
+
+# Start pane and window numbering at 1.
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Set a simple status bar theme.
+set -g status-bg colour234
+set -g status-fg colour136
+
+# Use TPM for plugin management
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+run '~/.tmux/plugins/tpm/tpm'
+TMUXCONF
+}
+
+# Run all setup steps in order.
+main() {
+    list_tmux_packages
+    install_packages
+    install_tmux_conf
+    build_osker
+    printf "Setup completed. You can now run make in each directory.\n"
+}
+
+main "$@"
+


### PR DESCRIPTION
## Summary
- ignore build logs
- enable `-Wall` warnings in `Posix/Makefile`
- document verbose build process in README
- install analysis tools and run `make --debug=v` during setup

## Testing
- `bash -n setup.sh`
- `sudo bash setup.sh` *(fails due to missing `../dirs.mk`)*

------
https://chatgpt.com/codex/tasks/task_e_684886dd8dc48331a32d442f0f6af5f2